### PR TITLE
fix rebar compile on pre-17 otp release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT = supervisor3
-PROJECT_VERSION = 1.1.3
+PROJECT_VERSION = 1.1.4
 
 otp_release_prefix = $(shell erl -noshell -eval 'io:put_chars([hd(erlang:system_info(otp_release))]), init:stop()')
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,1 @@
-% left empty
-% no support for pre-17 otp releases for rebar build
+{pre_hooks, [{compile, "make app"}]}.

--- a/src/supervisor3.app.src
+++ b/src/supervisor3.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,supervisor3,
  [{description,"A copy of supervisor.erl from the R16B Erlang/OTP with modifications"},
-  {vsn,"1.1.3"},
+  {vsn,"1.1.4"},
   {registered,[]},
   {applications,[kernel,stdlib]},
   {env,[]},
@@ -11,4 +11,4 @@
   {links, [{"Github", "https://github.com/klarna/supervisor3"}]},
   {build_tools, ["make", "rebar", "rebar3"]},
   {files, ["src", "README.md", "Makefile", "erlang.mk", "LICENSE", "LICENSE-MPL-RabbitMQ",
-           "rebar.config", "rebar.lock"]}]}.
+           "rebar.config"]}]}.


### PR DESCRIPTION
calling `make` as a pre_hook to avoid copying the compilation flags etc.
