### PR TITLE
Report child info with `id` key instead of `name`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT = supervisor3
-PROJECT_VERSION = 1.1.6
+PROJECT_VERSION = 1.1.7
 
 otp_release_prefix = $(shell erl -noshell -eval 'io:put_chars([hd(erlang:system_info(otp_release))]), init:stop()')
 

--- a/src/supervisor3.app.src
+++ b/src/supervisor3.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,supervisor3,
  [{description,"A copy of supervisor.erl from the R16B Erlang/OTP with modifications"},
-  {vsn,"1.1.6"},
+  {vsn,"1.1.7"},
   {registered,[]},
   {applications,[kernel,stdlib]},
   {env,[]},

--- a/src/supervisor3.erl
+++ b/src/supervisor3.erl
@@ -1653,14 +1653,14 @@ report_error(Error, Reason, Child, SupName) ->
 
 extract_child(Child) when is_list(Child#child.pid) ->
     [{nb_children, length(Child#child.pid)},
-     {name, Child#child.name},
+     {id, Child#child.name},
      {mfargs, Child#child.mfargs},
      {restart_type, Child#child.restart_type},
      {shutdown, Child#child.shutdown},
      {child_type, Child#child.child_type}];
 extract_child(Child) ->
     [{pid, Child#child.pid},
-     {name, Child#child.name},
+     {id, Child#child.name},
      {mfargs, Child#child.mfargs},
      {restart_type, Child#child.restart_type},
      {shutdown, Child#child.shutdown},


### PR DESCRIPTION
This PR makes supervisor report format consistent with the one in OTP supervisor
module: https://github.com/erlang/otp/blob/5ca92e2eac1e84fd22f60e7abc3aa2b0ff1cb42b/lib/stdlib/src/supervisor.erl#L1403.