### PR TITLE
Fix building on FreeBSD by using gmake.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,4 @@
-{pre_hooks, [{compile, "make app"}]}.
+{pre_hooks, [
+  {"freebsd", compile, "gmake app"},
+  {"(linux|darwin|solaris)", compile, "make app"}
+]}.


### PR DESCRIPTION
On BSD make is BSD make and gmake is GNU make.
This project uses syntax that is not supported BSD make.
its interesting to  see FreeBSD as supported platform in erlang.mk , but Makefile itself is using features that are not supported by BSD make.

