### PR TITLE
app.src: take vsn from git

### DIFF
--- a/src/supervisor3.app.src
+++ b/src/supervisor3.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,supervisor3,
  [{description,"A copy of supervisor.erl from the R16B Erlang/OTP with modifications"},
-  {vsn,"1.1.9"},
+  {vsn,"git"},
   {registered,[]},
   {applications,[kernel,stdlib]},
   {env,[]},


### PR DESCRIPTION
To avoid situations where git tag and app.src disagree.