### PR TITLE
Fixed stuck supervisor when received try_again_restart with delayed_restart in state

### DIFF
--- a/src/supervisor3.erl
+++ b/src/supervisor3.erl
@@ -648,6 +648,8 @@ handle_cast({try_again_restart,Name,Reason}, State) ->
     case lists:keysearch(Name,#child.name,State#state.children) of
         {value, Child = #child{pid=?restarting(_), restart_type=RestartType}} ->
             try_restart(RestartType, Reason, Child, State);
+        {value, Child = #child{pid=?delayed_restart(_), restart_type=RestartType}} ->
+            try_restart(RestartType, Reason, Child, State);
         _ ->
             {noreply,State}
     end.


### PR DESCRIPTION
Kflow's kflow_sup2 supervisor gets stuck during Kafka restart after the first delayed restart attempt fails, because the try_again_restart cast caused by send_after in maybe_restart/3 is dropped as the handling callback only matches on {restarting, Pid}, while the "pid" in delayed cases look like {delayed_restart, TRef}. So the restart logic never gets the control back. As a result, we never get to run do_restart_delay/4 where we would reset the timer for the next delayed_restart attempt. This leads to supervisor hanging infinitely with no children.