### PR TITLE
make post_init callback optional

### DIFF
--- a/src/supervisor3.erl
+++ b/src/supervisor3.erl
@@ -185,6 +185,7 @@
           [ChildSpec :: child_spec()]}}
     | ignore.
 
+-optional_callbacks([post_init/1]).
 -define(restarting(_Pid_), {restarting,_Pid_}).
 -define(delayed_restart(_TRef_), {delayed_restart,_TRef_}).
 


### PR DESCRIPTION
Having this callback optional makes sense because it is only called if
specific value is returned from init. Most users of supervisor3 do not
this callback, and are currently getting warnings if they don't add a
dummy implementation.