### PR TITLE
remove deprecated format_status/2

### DIFF
--- a/src/supervisor3.erl
+++ b/src/supervisor3.erl
@@ -81,7 +81,7 @@
 
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3]).
 -export([try_again_restart/3]).
 
 %%--------------------------------------------------------------------------
@@ -744,12 +744,6 @@ code_change(_, State, _) ->
         Error ->
             Error
     end.
-
-format_status(terminate, [_PDict, State]) ->
-    State;
-format_status(_, [_PDict, State]) ->
-    [{data, [{"State", State}]},
-     {supervisor, [{"Callback", State#state.module}]}].
 
 check_flags({Strategy, MaxIntensity, Period}) ->
     validStrategy(Strategy),


### PR DESCRIPTION
Triggers build error with OTP-27.

We don't need to replace it with format_status/1 as it doesn't do anything useful.