### PR TITLE
Convert to handle continue

### DIFF
--- a/src/supervisor3.erl
+++ b/src/supervisor3.erl
@@ -333,7 +333,6 @@ init({SupName, Mod, Args}) ->
         {ok, {SupFlags, StartSpec}} ->
             do_init(SupName, SupFlags, StartSpec, Mod, Args);
         post_init ->
-            %%self() ! {post_init, SupName, Mod, Args},
             {ok, #state{}, {continue, {post_init, SupName, Mod, Args}}};
         ignore ->
             ignore;

--- a/src/supervisor3.erl
+++ b/src/supervisor3.erl
@@ -81,7 +81,7 @@
 
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         handle_continue/2, terminate/2, code_change/3]).
 -export([try_again_restart/3]).
 
 %%--------------------------------------------------------------------------
@@ -333,8 +333,8 @@ init({SupName, Mod, Args}) ->
         {ok, {SupFlags, StartSpec}} ->
             do_init(SupName, SupFlags, StartSpec, Mod, Args);
         post_init ->
-            self() ! {post_init, SupName, Mod, Args},
-            {ok, #state{}};
+            %%self() ! {post_init, SupName, Mod, Args},
+            {ok, #state{}, {continue, {post_init, SupName, Mod, Args}}};
         ignore ->
             ignore;
         Error ->
@@ -679,6 +679,12 @@ handle_info({delayed_restart, {RestartType, _Reason, Child}}, State) ->
         _What ->
             {noreply, State}
     end;
+
+handle_info(Msg, State) ->
+    error_logger:error_msg("Supervisor received unexpected message: ~p~n",
+                           [Msg]),
+    {noreply, State}.
+
 %% [1] When we receive a delayed_restart message we want to reset the
 %% restarts field since otherwise the MaxT might not have elapsed and
 %% we would just delay again and again. Since a common use of the
@@ -686,7 +692,7 @@ handle_info({delayed_restart, {RestartType, _Reason, Child}}, State) ->
 %% (so that we don't end up bouncing around in non-delayed restarts)
 %% this is important.
 
-handle_info({post_init, SupName, Mod, Args}, State0) ->
+handle_continue({post_init, SupName, Mod, Args}, State0) ->
     Res = case Mod:post_init(Args) of
               {ok, {SupFlags, StartSpec}} ->
                   do_init(SupName, SupFlags, StartSpec, Mod, Args);
@@ -697,12 +703,7 @@ handle_info({post_init, SupName, Mod, Args}, State0) ->
     case Res of
         {ok, NewState} -> {noreply, NewState};
         {stop, Reason} -> {stop, Reason, State0}
-    end;
-
-handle_info(Msg, State) ->
-    error_logger:error_msg("Supervisor received unexpected message: ~p~n",
-                           [Msg]),
-    {noreply, State}.
+    end.
 
 %%
 %% Terminate this server.


### PR DESCRIPTION
Convert the `post_init` implementation to use `handle_continue` which was added to `gen_server` in OTP-21. This eliminates a race condition during startup of supervisors that use `post_init`.

Port [from brod](https://github.com/kafka4beam/brod/pull/625/commits/8de1d546e792da063ece507efcd4377d605f4fda)